### PR TITLE
update type-extensions comments

### DIFF
--- a/src/type-extensions.ts
+++ b/src/type-extensions.ts
@@ -9,17 +9,19 @@ import { ExampleHardhatRuntimeEnvironmentField } from "./ExampleHardhatRuntimeEn
 declare module "hardhat/types/config" {
   // This is an example of an extension to one of the Hardhat config values.
 
-  // We extend the UserConfig type, which represents the config as written
-  // by the users. Things are normally optional here.
+  // We extend the ProjectPathsUserConfig type, which represents the `paths`
+  // property as written by the users.  This is part of the HardhatUserConfig
+  // type, so things are normally optional here.
   export interface ProjectPathsUserConfig {
     newPath?: string;
   }
 
-  // We also extend the Config type, which represents the configuration
-  // after it has been resolved. This is the type used during the execution
-  // of tasks, tests and scripts.
-  // Normally, you don't want things to be optional here. As you can apply
-  // default values using the extendConfig function.
+  // We also extend the ProjectPathsConfig type, which represents the `paths`
+  // property after it has been resolved.  This is the type used during the
+  // execution of tasks, tests, and scripts.
+  // This is part of the HardhatConfig type; normally, you don't want things to
+  // be optional here, as you can apply default values using the extendConfig
+  // function.
   export interface ProjectPathsConfig {
     newPath: string;
   }


### PR DESCRIPTION
I found the comments in `type-extensions.ts` to be difficult to understand because (1) the `UserConfig` and `Config` types do not exist as written and (2) the source of the `ProjectPaths` types is not clear.